### PR TITLE
#165936332 Fix api documentation

### DIFF
--- a/authors/urls.py
+++ b/authors/urls.py
@@ -21,6 +21,7 @@ from rest_framework import permissions
 from rest_framework.routers import DefaultRouter
 
 from authors.apps.article_tag.views import ArticleTagViewSet
+from rest_framework.documentation import include_docs_urls
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -49,11 +50,7 @@ urlpatterns = [
     path('api/authors/', include('authors.apps.author_follows.urls')),
     path('api/', include('authors.apps.article_bookmarks.urls')),
     path('api/', include('authors.apps.notifications.urls')),
-    path(
-        "docs/",
-        schema_view.with_ui("swagger", cache_timeout=0),
-        name="schema-swagger-ui",
-    ),
+    path('docs/', include_docs_urls(title='Authors Haven API')),
     path('api/', include('authors.apps.profiles.urls')),
     path('api/articles/', include('authors.apps.reports.urls')),
 ]


### PR DESCRIPTION
#### What does this PR do?
- Have the API documentation working

#### Description of Task to be completed?
- Fix the bug that caused the documentation to break

#### How should this be manually tested?
- After successfully setting up the project
- Hit the documentation endpoint `http://127.0.0.1:8000/docs/`

#### What are the relevant pivotal tracker stories?
[165936332](https://www.pivotaltracker.com/story/show/165936332)

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2019-05-14 at 12 36 04 PM" src="https://user-images.githubusercontent.com/39102955/57687872-e696b180-7644-11e9-898d-f55d258a997a.png">

