### PR TITLE
chore(password reset template): remove link and replace with token text

### DIFF
--- a/authors/apps/authentication/tests/test_user_registration.py
+++ b/authors/apps/authentication/tests/test_user_registration.py
@@ -161,6 +161,8 @@ class TestUserRegistrationView(TestCase):
             content_type="application/json",
             data=json.dumps(self.user),
         )
+        print(response.data)
+
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data['errors']['error'][0], "Your password should not be the same as or contain your username")
 

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -285,9 +285,10 @@ def password_reset_token_created(
         "current_user": reset_password_token.user,
         "username": reset_password_token.user.username,
         "email": reset_password_token.user.email,
-        "reset_password_url": "{}{}{}".format(
-            settings.WEB_HOST, "/api/reset-password/", reset_password_token.key
-        ),
+        "key": reset_password_token.key,
+        # "reset_password_url": "{}{}{}".format(
+        #     settings.WEB_HOST, "/api/reset-password/", reset_password_token.key
+        # ),
     }
 
     html_content = render_to_string(template_name, context)

--- a/templates/user_reset_password.html
+++ b/templates/user_reset_password.html
@@ -408,7 +408,7 @@
                           <td class="copy" style="padding-top:0;padding-bottom:0;padding-right:0;padding-left:0;vertical-align:top;text-align:left;">
                             <h1 style="font-family:sans-serif;font-weight:bold;Margin-top:0;text-align:left;font-size:22px;line-height:26px;Margin-bottom:20px;color:#445359;">Hello {{username}}</h1>
 
-                            <p style="Margin-top:0;font-weight:normal;color:#677483;font-family:sans-serif;font-size:14px;line-height:25px;Margin-bottom:15px;">If you are here, it is evident you would like to change your password. To change your password, click on the link below.</p>
+                            <p style="Margin-top:0;font-weight:normal;color:#677483;font-family:sans-serif;font-size:14px;line-height:25px;Margin-bottom:15px;">If you are here, it is evident you would like to change your password. To change your password, copy the token below, and paste it in the token field of the password reset form.</p>
                           </td>
                         </tr>
                       </table>
@@ -445,7 +445,7 @@
                                             <center style="color:#ffffff;font-family:sans-serif;font-size:13px;font-weight:bold;">Activate your account and log in</center>
                                           </v:roundrect>
                                         <![endif]-->
-                                      <a href="{{reset_password_url}}" style="mso-hide:all;background-color:#62a30c;background-image:url(https://img.createsend1.com/img/onboarding/btn-green.png);background-repeat:repeat-x;border-width:1px;border-style:solid;border-color:#538c02;border-radius:3px;color:#ffffff;display:inline-block;font-weight:normal;font-family:sans-serif;font-size:14px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;text-shadow:1px 2px 1px #548e19;box-shadow:0px 2px 2px 0px #e2ecd4;-webkit-box-shadow:0px 2px 2px 0px #e2ecd4;-moz-box-shadow:0px 2px 2px 0px #e2ecd4;width:260px;" target="_blank">Reset Password</a>
+                                      <div style="background-color:#62a30c;font-weight:normal;font-family:sans-serif;font-size:18px;line-height:45px;text-align:center;text-decoration:none;-webkit-text-size-adjust:none;text-shadow:1px 2px 1px #548e19;box-shadow:0px 2px 2px 0px #e2ecd4;-webkit-box-shadow:0px 2px 2px 0px #e2ecd4;-moz-box-shadow:0px 2px 2px 0px #e2ecd4;width:260px;color:#ffffff;width:90%;" >{{key}}</div>
                                     </div>
                                   </td>
                                 </tr>


### PR DESCRIPTION
### What does this PR do? 
• Removes backend link
• Replaces it with the plain token

### Background context
• The link redirects to the backend, not the frontend.
• We need to redirect the user to the frontend, but there is no way of doing so with a dynamic URL, considering the 3rd party library that was used for the password reset handling
•So we are resorting to letting the user copy the token and pasting it in the password reset form.

### Any pictures?
![image](https://user-images.githubusercontent.com/12115624/59409172-5754f900-8dbe-11e9-9c8b-4f27b61e9bd3.png)
