### PR TITLE
Chore(auth token): add username and email to auth token

### DIFF
--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -136,6 +136,8 @@ class User(AbstractBaseUser, PermissionsMixin):
         token = jwt.encode(
             {
                 "id": self.pk,
+                "username": self.get_short_name(),
+                "email": self.email,
                 "iat": datetime.utcnow(),
                 "exp": datetime.utcnow() + timedelta(hours=3),
             },

--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -4,10 +4,11 @@ from .models import Profile
 
 class ProfileSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username')
+    email = serializers.CharField(source='user.email')
     bio = serializers.CharField(allow_blank=True, required=False)
 
     class Meta:
         model = Profile
-        fields = ('username', 'bio', 'image',)
+        fields = ('firstname', 'lastname','username', 'bio', 'image','email')
         read_only_fields = ('username',)
 


### PR DESCRIPTION
What does this PR do?
• Adds username and email information in the authorization token

Background context
• The endpoint for social authentication only returns a token and yet we also need the username and email of the authenticated user in the frontend on logging in.

•  The token now contains the info below

```
{
  "id": integer,
  "username":string,
  "email": string
}
```