### PR TITLE
#16673321 bug status of like or dislike

### DIFF
--- a/authors/apps/article_likes/tests/test_article_like.py
+++ b/authors/apps/article_likes/tests/test_article_like.py
@@ -95,3 +95,17 @@ class TestArticleLikeViews(TestCase):
         url = f"/api/articles/{self.article_2.slug}/dislidfdfsdfke"
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
+
+    def test_article_get_like_status(self):
+        self.client.force_authenticate(user=self.user)
+        url = f"/api/articles/{self.article_1.slug}/like"
+        self.client.post(url)
+        url_like_status = f"/api/articles/{self.article_1.slug}/likestatus/"
+        response  = self.client.get(url_like_status)
+        self.assertEqual(response.status_code, 200)
+
+    def test_article_get_like_none(self):
+        self.client.force_authenticate(user=self.user)
+        url_like_status = f"/api/articles/{self.article_1.slug}/likestatus/"
+        response  = self.client.get(url_like_status)
+        self.assertEqual(response.status_code, 200)

--- a/authors/apps/article_likes/urls.py
+++ b/authors/apps/article_likes/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import ArticleLikesDislikesViews
+from .views import (ArticleLikesDislikesViews, LikeArticleStatus)
 
 urlpatterns = [
     # /articles/slug/like_status/
-    path("<str:like_status>", ArticleLikesDislikesViews.as_view(), name="liking")
+    path("<str:like_status>", ArticleLikesDislikesViews.as_view(), name="liking"),
+    path('likestatus/', LikeArticleStatus.as_view()),
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -96,7 +96,7 @@ class ListCreateArticlesView(APIView, CustomPaginationMixin):
             articles_list = []
 
             for article in all_articles:
-                article["likeCount"] = [like_grand_count(article)]
+                article["likeCount"] = like_grand_count(article)
                 articles_list.append(article)
             return self.get_paginated_response(
                 {

--- a/authors/apps/comments/models.py
+++ b/authors/apps/comments/models.py
@@ -26,7 +26,7 @@ class CommentLikeDislike(models.Model):
     user = models.ForeignKey(Profile, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.like
+        return str(self.like)
 
 class CommentEditHistory(models.Model):
     """Model for collecting edited history of the comments"""

--- a/authors/apps/comments/tests/test_like_dislike_comment.py
+++ b/authors/apps/comments/tests/test_like_dislike_comment.py
@@ -15,48 +15,193 @@ class TestDislikeAndLikeCommment(BaseCommentTests):
             content_type="application/json",
             data=json.dumps({"comment":{"body": "Fake article"}}),
         )
+
+        comment_id = response.data.get("comment").get("id")
+
         self.assertEqual(response.status_code, 201)
         response1 = self.client.post(
-            f"/api/articles/{self.article.slug}/comments/1/like",
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/like",
             content_type="application/json",
         )
         self.assertEqual(response1.status_code, 200)
         self.assertEqual(
             response1.data["message"],
-            "You have liked this comment",
+            "You have successfully liked this comment",
         )
         response2 = self.client.post(
-            f"/api/articles/{self.article.slug}/comments/1/like",
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/like",
             content_type="application/json",
         )
         self.assertEqual(response2.status_code, 200)
         self.assertEqual(
             response2.data["message"],
-            "You have already liked this comment",
+            "You have successfully revoked your like on this comment",
         )
 
         response3 = self.client.get(
-            f"/api/articles/{self.article.slug}/comments/1/like",
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/like",
             content_type="application/json",
         )
         self.assertEqual(response3.status_code, 200)
 
-        response4 = self.client.delete(
-            f"/api/articles/{self.article.slug}/comments/1/dislike",
+    def test_comment_change_dislike_to_like(self):
+        """test if a user can like a comment they previusly disliked"""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user.token}")
+        response = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/",
+            content_type="application/json",
+            data=json.dumps({"comment":{"body": "Fake article"}}),
+        )
+        comment_id = response.data.get("comment").get("id")
+        self.assertEqual(response.status_code, 201)
+        self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/dislike",
             content_type="application/json",
         )
-        self.assertEqual(response4.status_code, 200)
-        self.assertEqual(
-            response4.data["message"],
-            "Your like has been successfully revoked",
-        )
-        response5 = self.client.delete(
-            f"/api/articles/{self.article.slug}/comments/1/dislike",
+  
+        response2 = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/like",
             content_type="application/json",
         )
-        self.assertEqual(response5.status_code, 400)
+    
+        self.assertEqual(response2.status_code, 200)
         self.assertEqual(
-            response5.data["message"],
-            "You have not liked this comment",
+            response2.data.get("message"),
+            "You now like this comment",
+        )
+        
+    def test_user_revoke_dislike(self):
+        """test if a user can undo a dislike of a comment they 
+            previusly disliked"""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user.token}")
+        response = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/",
+            content_type="application/json",
+            data=json.dumps({"comment":{"body": "Fake article"}}),
+        )
+        comment_id = response.data.get("comment").get("id")
+        self.assertEqual(response.status_code, 201)
+        self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/dislike",
+            content_type="application/json",
+        )
+
+        response2 = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/dislike",
+            content_type="application/json",
+        )
+    
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(
+            response2.data.get("message"),
+            "You have successfully revoked your dislike on this comment",
+        )
+
+    def test_user_change_like_to_dislike(self):
+        """test if a user can dislike a comment they previusly liked"""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user.token}")
+        response = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/",
+            content_type="application/json",
+            data=json.dumps({"comment":{"body": "Fake article"}}),
+        )
+        comment_id = response.data.get("comment").get("id")
+        self.assertEqual(response.status_code, 201)
+        self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/like",
+            content_type="application/json",
+        )
+
+        response2 = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/dislike",
+            content_type="application/json",
+        )
+    
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(
+            response2.data.get("message"),
+            "You now dislike this comment",
+        )
+
+    def test_user_get_dislikes_count(self):
+        """test if a user can get number of dislikes"""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user.token}")
+        response = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/",
+            content_type="application/json",
+            data=json.dumps({"comment":{"body": "Fake article"}}),
+        )
+        comment_id = response.data.get("comment").get("id")
+        self.assertEqual(response.status_code, 201)
+        self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/like",
+            content_type="application/json",
+        )
+
+        self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/dislike",
+            content_type="application/json",
+        )
+
+        response2 = self.client.get(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/dislike",
+            content_type="application/json",
+        )
+    
+        self.assertEqual(response2.status_code, 200)
+
+    def test_user_get_like_status(self):
+        """test if a user can get the state of a like/dislike of a 
+        comment"""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user.token}")
+        response = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/",
+            content_type="application/json",
+            data=json.dumps({"comment":{"body": "Fake article"}}),
+        )
+        comment_id = response.data.get("comment").get("id")
+        self.assertEqual(response.status_code, 201)
+        self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/like",
+            content_type="application/json",
+        )
+
+        self.client.post(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/dislike",
+            content_type="application/json",
+        )
+
+        response2 = self.client.get(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/likestatus",
+            content_type="application/json",
+        )
+    
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(
+            response2.data.get("status"),
+            False,
+        )
+
+    def test_user_get_like_none(self):
+        """test if a user can get the state of like or dislike 
+        if they have never liked or disliked a comment"""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user.token}")
+        response = self.client.post(
+            f"/api/articles/{self.article.slug}/comments/",
+            content_type="application/json",
+            data=json.dumps({"comment":{"body": "Fake article"}}),
+        )
+        comment_id = response.data.get("comment").get("id")
+        self.assertEqual(response.status_code, 201)
+
+        response2 = self.client.get(
+            f"/api/articles/{self.article.slug}/comments/{comment_id}/likestatus",
+            content_type="application/json",
+        )
+    
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(
+            response2.data.get("status"),
+            "none",
         )
         

--- a/authors/apps/comments/urls.py
+++ b/authors/apps/comments/urls.py
@@ -2,7 +2,7 @@
 from django.urls import path
 from authors.apps.comments.views import (
     ListCreateCommentView, UpdateDestroyCommentView,
-    LikeComment, DislikeComment, CommentHistoryViewSet
+    LikeComment, LikeCommentStatus, DislikeComment, CommentHistoryViewSet
 )
 
 urlpatterns = [
@@ -18,6 +18,8 @@ urlpatterns = [
     ),
     path('comments/<int:pk>/like',
          LikeComment.as_view()),
+    path('comments/<int:pk>/likestatus',
+         LikeCommentStatus.as_view()),
     path('comments/<int:pk>/dislike',
          DislikeComment.as_view()),
     path('comments/<int:pk>/history',


### PR DESCRIPTION
#### What does this PR do?
Allows a user to view the status of like/dislike for a particular article.
#### Description of Task to be completed?
- A user can view if they liked or disliked an article
- A user can see if they liked or disliked a comment
#### How should this be manually tested?
- This can be manually tested by going to the urls:
  - Comment like: base_url/articles/<article_slug>/comments/<comment_id>/likestatus
  - Article like: base_url/articles/<article_slug>/likestatus/
#### Any background context you want to provide?
Before, A user wasn't able to view whether they have liked or disliked a comment/article. With this implementation, it is now possible.
#### What are the relevant pivotal tracker stories?
[#166733215](https://www.pivotaltracker.com/story/show/166733215)
#### Screenshots (if appropriate)
- None
#### Questions:
- None