### PR TITLE
Get the initial bookmark status for a user on an article

### DIFF
--- a/authors/apps/article_bookmarks/tests/test_bookmark.py
+++ b/authors/apps/article_bookmarks/tests/test_bookmark.py
@@ -61,7 +61,7 @@ class TestBookmark(TransactionTestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.data, self.auth_error)
 
-    def test_authenticated_user_cannot_add_a_bookmark_with_invalid_article_slugdserv(
+    def test_authenticated_user_cannot_add_a_bookmark_with_invalid_article_slug(
         self
     ):
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user.token}")
@@ -112,3 +112,25 @@ class TestBookmark(TransactionTestCase):
             response.data["message"],
             "Article has been unBookmarked Successfully",
         )
+
+    def test_unauthenticated_user_cannot_check_bookmark_status(self):
+        response = self.client.get("/api/articles/{slug}/bookmark_status/")
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data, self.auth_error)
+
+    def test_authenticated_user_can_check_bookmark_status(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user.token}")
+        self.client.post(f"/api/articles/{self.slug}/bookmark/")
+
+        response = self.client.get(f"/api/articles/{self.slug}/bookmark_status/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['isBookmarked'], True)
+
+    def test_isBookmarked_is_false_when_the_article_is_not_bookmarked(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.user2.token}")
+        response = self.client.get(f"/api/articles/{self.slug}/bookmark_status/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['isBookmarked'], False)

--- a/authors/apps/article_bookmarks/urls.py
+++ b/authors/apps/article_bookmarks/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path
 
-from .views import CreateDestroyBookmarksView, ListBookmarksView
+from .views import (
+    CreateDestroyBookmarksView,
+    ListBookmarksView,
+    RetrieveBookmarkStatusView
+)
 
 urlpatterns = [
     path(
@@ -9,4 +13,9 @@ urlpatterns = [
         name="create_destroy_bookmarks",
     ),
     path("bookmarks/", ListBookmarksView.as_view(), name="get_bookmarks"),
+    path(
+        "articles/<str:slug>/bookmark_status/",
+        RetrieveBookmarkStatusView.as_view(),
+        name="get_bookmark_status"
+    ),
 ]

--- a/authors/apps/article_bookmarks/views.py
+++ b/authors/apps/article_bookmarks/views.py
@@ -50,6 +50,39 @@ class CreateDestroyBookmarksView(APIView):
         )
 
 
+class RetrieveBookmarkStatusView(APIView):
+    """
+        get:
+        Get the status of a user's article bookmark
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        current_user = request.user
+        slug = kwargs["slug"]
+
+        article = get_object_or_404(Article, slug=slug)
+
+        # get bookmarks for this user and article
+        user_bookmarks = Bookmark.objects.filter(
+            user=request.user.username,
+            article=article.id
+        )
+
+        bookmarked = False
+
+        if len(user_bookmarks) > 0:
+            bookmarked = True
+
+        return Response(
+            data={
+                "isBookmarked": bookmarked,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
 class ListBookmarksView(APIView):
     """
         get:

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -285,10 +285,10 @@ def password_reset_token_created(
         "current_user": reset_password_token.user,
         "username": reset_password_token.user.username,
         "email": reset_password_token.user.email,
-        "key": reset_password_token.key,
-        # "reset_password_url": "{}{}{}".format(
-        #     settings.WEB_HOST, "/api/reset-password/", reset_password_token.key
-        # ),
+        # "key": reset_password_token.key,
+        "reset_password_url": "{}{}{}".format(
+            settings.WEB_HOST, "/api/reset-password/", reset_password_token.key
+        ),
     }
 
     html_content = render_to_string(template_name, context)

--- a/authors/apps/core/exceptions.py
+++ b/authors/apps/core/exceptions.py
@@ -1,5 +1,6 @@
 from rest_framework.views import exception_handler
 
+
 def core_exception_handler(exc, context):
     # If an exception is thrown that we don't explicitly handle here, we want
     # to delegate to the default exception handler offered by DRF. If we do
@@ -16,11 +17,12 @@ def core_exception_handler(exc, context):
 
     if exception_class in handlers:
         # If this exception is one that we can handle, handle it. Otherwise,
-        # return the response generated earlier by the default exception 
+        # return the response generated earlier by the default exception
         # handler.
         return handlers[exception_class](exc, context, response)
 
     return response
+
 
 def _handle_generic_error(exc, context, response):
     # This is about the most straightforward exception handler we can create.


### PR DESCRIPTION
## What does this PR do?
• Fetches the initial bookmark status for a user on an article

## Any background information?
• A user can toggle a bookmark, but the bookmark needs to be set to true if the had already bookmarked the article.

## How can this be manually tested?
• Signup and login
• Create an article
• Hit the endpoint `/api/articles/<article-slug>/bookmark_status/

## Any screen shots
![image](https://user-images.githubusercontent.com/12115624/59828947-d01afe80-9344-11e9-9102-6c90ca9a0d44.png)
